### PR TITLE
修复多次调用onShutdown的bug

### DIFF
--- a/src/Http/HlsPlayer.cpp
+++ b/src/Http/HlsPlayer.cpp
@@ -367,8 +367,10 @@ void HlsPlayerImp::onPlayResult(const SockException &ex) {
 }
 
 void HlsPlayerImp::onShutdown(const SockException &ex) {
-    PlayerImp<HlsPlayer, PlayerBase>::onShutdown(ex);
-    _demuxer = nullptr;
+    if (_demuxer) {
+        PlayerImp<HlsPlayer, PlayerBase>::onShutdown(ex);
+        _demuxer = nullptr;
+    }
 }
 
 vector<Track::Ptr> HlsPlayerImp::getTracks(bool ready) const {


### PR DESCRIPTION
当HlsPlayer拉取索引失败后会触发PlayerProxy的重试机制.
但是这里就有一个bug会导致重试次数不准确.
因为HlsPlayer播放失败会调用onShutdown.
然后回调PlayerProxy.
之后如果触发重试, 那么在HlsPlayer析构的时候又会在调用一次onShutdown.
这时候是安全的, 因为_on_shutdown已经被置空.
但是如果重试时又再次失败, 那么首先会调用
onPlayResult
这时候在PlayerProxy中会再次触发重试, 紧接着HlsPlayer析构, 又会调用一次onShutdown, 那么就又会触发一次重试.

修复方法有很多, 最简单的就是直接在
onShutdown中判断如果没有_demuxer就不需要父类的onShutdown方法来释放资源与重连了.
因为针对HlsPlayer来说, 如果重试拉取索引没有成功, 应该没有什么资源需要在onShutdown方法中释放了.

当然更完善的修复应该是在PlayerProxy中增加相关的判断逻辑, 给rePlay一个状态.
确保rePlay执行完成前, 不再执行一次rePlay.

具体哪种方式, 大佬您可以看着办.